### PR TITLE
Fix error message for empty bucket name

### DIFF
--- a/storage/bucket_test.go
+++ b/storage/bucket_test.go
@@ -42,7 +42,7 @@ func TestGetBucketWithEmptyName(t *testing.T) {
 	}
 	if result.Data.Total != 0 {
 		// If the API returns buckets even with an empty name, this is unexpected
-		t.Error("GetBucket with empty name returned empty result")
+		t.Error("GetBucket with empty name returned non-empty result")
 	}
 	t.Logf("All buckets: %+v", result)
 }


### PR DESCRIPTION
## Summary
- clarify error text for TestGetBucketWithEmptyName to show buckets were unexpectedly returned

## Testing
- `go test ./...` *(fails: Missing Authorization header)*

------
https://chatgpt.com/codex/tasks/task_e_68507ff7fe488331b06d1e29ac39ff80