### PR TITLE
Add test verifying default content type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/LeonardoRyuta/apillon-storage
 
 go 1.24.4
+
+require gopkg.in/h2non/gock.v1 v1.1.2
+
+require github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
+gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
+gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=

--- a/storage/start_upload_default_test.go
+++ b/storage/start_upload_default_test.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	gock "gopkg.in/h2non/gock.v1"
+)
+
+func TestStartUploadFilesToBucket_DefaultContentType(t *testing.T) {
+	defer gock.Off()
+
+	bucketUUID := "test-bucket-uuid"
+	path := "/storage/buckets/" + bucketUUID + "/upload"
+
+	var body string
+
+	// Mock the POST request and capture the request body
+	gock.New("https://api.apillon.io").
+		Post(path).
+		AddMatcher(func(req *http.Request, ereq *gock.Request) (bool, error) {
+			b, _ := io.ReadAll(req.Body)
+			body = string(b)
+			return true, nil
+		}).
+		Reply(200).
+		JSON(map[string]any{
+			"data": map[string]any{
+				"sessionUuid": "session",
+				"files":       []map[string]any{{"url": "http://example.com"}},
+			},
+		})
+
+	files := []FileMetadata{{FileName: "test.txt"}}
+
+	_, err := StartUploadFilesToBucket(bucketUUID, files)
+	if err != nil {
+		t.Fatalf("StartUploadFilesToBucket returned error: %v", err)
+	}
+
+	if !gock.IsDone() {
+		t.Fatalf("expected HTTP request was not made")
+	}
+
+	if !strings.Contains(body, "\"contentType\":\"text/plain\"") {
+		t.Errorf("request body does not contain default content type: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary
- add gock dependency for HTTP mocking
- create `TestStartUploadFilesToBucket_DefaultContentType` verifying missing content type defaults to `text/plain`

## Testing
- `go test ./...` *(fails: missing authorization when hitting real API)*

------
https://chatgpt.com/codex/tasks/task_e_68507ff93a688331ac36bc462a6bd973